### PR TITLE
Repair nil check of compose()

### DIFF
--- a/account_e2e_test.go
+++ b/account_e2e_test.go
@@ -70,18 +70,27 @@ func TestClient_InternalTxByAddress(t *testing.T) {
 }
 
 func TestClient_ERC20Transfers(t *testing.T) {
-	const wantLen = 3
+	const (
+		wantLen1 = 3
+		wantLen2 = 458
+	)
 
 	var a, b = 3273004, 3328071
 	var contract, address = "0xe0b7927c4af23765cb51314a0e0521a9645f0e2a", "0x4e83362442b8d1bec281594cea3050c8eb01311c"
 	txs, err := api.ERC20Transfers(&contract, &address, &a, &b, 1, 500)
-	noError(t, err, "api.ERC20Transfers")
+	noError(t, err, "api.ERC20Transfers 1")
 
 	//j, _ := json.MarshalIndent(txs, "", "  ")
 	//fmt.Printf("%s\n", j)
 
-	if len(txs) != wantLen {
-		t.Errorf("got txs length %v, want %v", len(txs), wantLen)
+	if len(txs) != wantLen1 {
+		t.Errorf("got txs length %v, want %v", len(txs), wantLen1)
+	}
+
+	txs, err = api.ERC20Transfers(nil, &address, nil, &b, 1, 500)
+	noError(t, err, "api.ERC20Transfers 2")
+	if len(txs) != wantLen2 {
+		t.Errorf("got txs length %v, want %v", len(txs), wantLen2)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -62,6 +62,13 @@ func (c *Client) call(module, action string, param map[string]interface{}, outco
 		defer c.AfterRequest(module, action, param, outcome, err)
 	}
 
+	// recover if there shall be an panic
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("[ouch! panic recovered] please report this with what you did and what you expected, panic detail: %v", r)
+		}
+	}()
+
 	req, err := http.NewRequest(http.MethodGet, c.craftURL(module, action, param), http.NoBody)
 	if err != nil {
 		err = wrapErr(err, "http.NewRequest")

--- a/helper.go
+++ b/helper.go
@@ -9,16 +9,28 @@ package etherscan
 
 import (
 	"math/big"
+	"reflect"
 	"strconv"
 	"time"
 )
 
 // compose adds input to param, whose key is tag
-// if input is nil, compose is a no-op.
+// if input is nil or nil of some type, compose is a no-op.
 func compose(param map[string]interface{}, tag string, input interface{}) {
+	// simple situation
 	if input == nil {
 		return
 	}
+
+	// needs dig further
+	v := reflect.ValueOf(input)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Interface:
+		if v.IsNil() {
+			return
+		}
+	}
+
 	param[tag] = input
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -43,7 +43,7 @@ func valueToStr(v reflect.Value) (str string) {
 	case reflect.Int:
 		str = strconv.FormatInt(v.Int(), 10)
 	default:
-		panic(fmt.Sprintf("valueToStr: %v is of unexpected kind %q", v.Interface(), v.Kind()))
+		panic(fmt.Sprintf("valueToStr: %v is of unexpected kind %q", v, v.Kind()))
 	}
 	return
 }


### PR DESCRIPTION
An interface is nil only when both its type and value are nil.
Detail: https://golang.org/doc/faq#nil_error

A big thank you to llya Evdokimov (@engenegr) for finding this bug (#3) !  ;)