### PR TITLE
TraceID from int to string

### DIFF
--- a/response.go
+++ b/response.go
@@ -60,7 +60,7 @@ type InternalTx struct {
 	Type            string  `json:"type"`
 	Gas             int     `json:"gas,string"`
 	GasUsed         int     `json:"gasUsed,string"`
-	TraceID         string     `json:"traceId"`
+	TraceID         string  `json:"traceId"`
 	IsError         int     `json:"isError,string"`
 	ErrCode         string  `json:"errCode"`
 }


### PR DESCRIPTION
The etherscan api will sometimes return  the string 0_0 as the traceID instead of an int.