### PR TITLE
TokenDecimal from int to string

### DIFF
--- a/account.go
+++ b/account.go
@@ -84,7 +84,9 @@ func (c *Client) ERC20Transfers(contractAddress, address *string, startBlock *in
 		"page":   page,
 		"offset": offset,
 	}
-	compose(param, "contractaddress", contractAddress)
+	if len(*contractAddress) > 0 {
+		compose(param, "contractaddress", contractAddress)
+	}
 	compose(param, "address", address)
 	compose(param, "startblock", startBlock)
 	compose(param, "endblock", endBlock)

--- a/response.go
+++ b/response.go
@@ -78,7 +78,7 @@ type ERC20Transfer struct {
 	Value             *BigInt `json:"value"`
 	TokenName         string  `json:"tokenName"`
 	TokenSymbol       string  `json:"tokenSymbol"`
-	TokenDecimal      uint8   `json:"tokenDecimal,string"`
+	TokenDecimal      string  `json:"tokenDecimal"`
 	TransactionIndex  int     `json:"transactionIndex,string"`
 	Gas               int     `json:"gas,string"`
 	GasPrice          *BigInt `json:"gasPrice"`


### PR DESCRIPTION
TokenDecimal is sometimes returning an empty string instead of the expected int