### PR TITLE
method ERC20Transfers also need desc  param, otherwise we can only get the old data

### DIFF
--- a/account.go
+++ b/account.go
@@ -87,7 +87,7 @@ func (c *Client) InternalTxByAddress(address string, startBlock *int, endBlock *
 //
 // More information can be found at:
 // https://github.com/nanmu42/etherscan-api/issues/8
-func (c *Client) ERC20Transfers(contractAddress, address *string, startBlock *int, endBlock *int, page int, offset int) (txs []ERC20Transfer, err error) {
+func (c *Client) ERC20Transfers(contractAddress, address *string, startBlock *int, endBlock *int, page int, offset int, desc bool) (txs []ERC20Transfer, err error) {
 	param := M{
 		"page":   page,
 		"offset": offset,
@@ -96,6 +96,12 @@ func (c *Client) ERC20Transfers(contractAddress, address *string, startBlock *in
 	compose(param, "address", address)
 	compose(param, "startblock", startBlock)
 	compose(param, "endblock", endBlock)
+
+	if desc {
+		param["sort"] = "desc"
+	} else {
+		param["sort"] = "asc"
+	}
 
 	err = c.call("account", "tokentx", param, &txs)
 	return


### PR DESCRIPTION
method ERC20Transfers also need desc  param, otherwise we can only get the old data