### PR TITLE
Improve GetLogs function

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -8,12 +8,29 @@
 package etherscan
 
 // GetLogs gets logs that match "topic" emitted by the specified "address" between the "fromBlock" and "toBlock"
-func (c *Client) GetLogs(fromBlock, toBlock int, address, topic string) (logs []Log, err error) {
+func (c *Client) GetLogs(address string, fromBlock, toBlock *int, topic *string, page, offset *int) (logs []Log, err error) {
 	param := M{
-		"fromBlock": fromBlock,
-		"toBlock":   toBlock,
-		"topic0":    topic,
-		"address":   address,
+		"address": address,
+	}
+
+	if fromBlock != nil {
+		param["fromBlock"] = *fromBlock
+	}
+
+	if toBlock != nil {
+		param["toBlock"] = *toBlock
+	}
+
+	if topic != nil {
+		param["topic0"] = *topic
+	}
+
+	if page != nil {
+		param["page"] = *page
+	}
+
+	if offset != nil {
+		param["offset"] = *offset
 	}
 
 	err = c.call("logs", "getLogs", param, &logs)

--- a/logs_e2e_test.go
+++ b/logs_e2e_test.go
@@ -19,7 +19,11 @@ func TestClient_GetLogs(t *testing.T) {
 		},
 	}
 
-	actualLogs, err := api.GetLogs(379224, 379225, "0x33990122638b9132ca29c723bdf037f1a891a70c", "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")
+	fromBlock := 379224
+	toBlock := 379225
+	topic := "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+
+	actualLogs, err := api.GetLogs("0x33990122638b9132ca29c723bdf037f1a891a70c", &fromBlock, &toBlock, &topic, nil, nil)
 
 	noError(t, err, "api.GetLogs")
 


### PR DESCRIPTION
Hi,

I've improved the GetLogs function because some of mandatory parameters are not mandatory for the etherscan API (e.g: `toBlock`, `fromBlock` and `topic`).

I've also add missing parameter `page` and `offset`.

Tests execution:
<img width="291" alt="image" src="https://github.com/nanmu42/etherscan-api/assets/64586968/2f58a094-0dbe-49da-8830-bf4e64042b98">

Feel free to ask me any change in my codebase

Have a good day ;) 