### PR TITLE
refactor: using `http.DefaultClient` as default http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,9 +77,8 @@ func NewCustomized(config Customization) *Client {
 	if config.Client != nil {
 		httpClient = config.Client
 	} else {
-		httpClient = &http.Client{
-			Timeout: config.Timeout,
-		}
+		httpClient = http.DefaultClient
+		httpClient.Timeout = config.Timeout
 	}
 	return &Client{
 		coon:          httpClient,


### PR DESCRIPTION
This PR added support for using the `HTTP_PROXY` environment HTTP proxy setting when we init default client `etherscan.New(etherscan.Mainnet, os.Getenv("ETHERSCAN_API_KEY"))`